### PR TITLE
add .gitattributes: ignore codemirror.js in language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+static/js/codemirror.js linguist-vendored


### PR DESCRIPTION
now the repository is seen as a CL project.

The mecanism is based on
https://github.com/github/linguist