### PR TITLE
Use closer-mop instead of shadow-importing some mop symbols

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -5,14 +5,6 @@
   (:shadowing-import-from #:cl-css #:%)
   (:import-from #:anaphora #:aif #:awhen #:it)
   (:import-from #:alexandria #:with-gensyms)
-  (:shadowing-import-from
-   #+openmcl-native-threads #:ccl
-   #+cmu #:pcl
-   #+sbcl #:sb-pcl
-   #+lispworks #:hcl
-   #+allegro #:mop
-   #+clisp #:clos
-   #:class-slots #:slot-definition-name)
   (:shadowing-import-from #:fact-base #:lookup)
   (:export :bar-graph :draw-bar-graph :main :str :htm :who-ps-html :new :create :@ :chain :define-css))
 

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -71,7 +71,7 @@
 ;;;;; Error-related
 (defun instance->alist (instance)
   (loop for s in (closer-mop:class-slots (class-of instance))
-     for slot-name = (slot-definition-name s)
+     for slot-name = (closer-mop:slot-definition-name s)
      when (slot-boundp instance slot-name)
      collect (cons (intern (symbol-name slot-name) :keyword)
 		   (slot-value instance slot-name))))


### PR DESCRIPTION
* complete the use of closer-mop, so that the :shadowing-import-from of the two symbols is no longer necessary
* Did run the tests successfully in sbcl and clasp, but they seem to be a stub